### PR TITLE
feat: optional TwelveLabs Pegasus video understanding for shot labeling

### DIFF
--- a/App/App.axaml.cs
+++ b/App/App.axaml.cs
@@ -279,7 +279,20 @@ public partial class App : Avalonia.Application
 
         // Services - 保持现有业务逻辑
         services.AddSingleton<VideoAnalysisService>();
-        services.AddSingleton<IVideoAnalysisService>(sp => sp.GetRequiredService<VideoAnalysisService>());
+        // TwelveLabs Pegasus 选配：配置了 TWELVELABS_API_KEY 时用 Pegasus 丰富分镜描述，
+        // 否则装饰器透传本地启发式结果，行为不变。
+        services.AddSingleton(_ => Storyboard.AI.Core.TwelveLabsOptions.FromEnvironment());
+        services.AddSingleton<IVideoAnalysisService>(sp =>
+        {
+            var heuristic = sp.GetRequiredService<VideoAnalysisService>();
+            var options = sp.GetRequiredService<Storyboard.AI.Core.TwelveLabsOptions>();
+            if (!options.IsEnabled)
+                return heuristic;
+            return new TwelveLabsVideoAnalysisService(
+                heuristic,
+                options,
+                sp.GetRequiredService<ILogger<TwelveLabsVideoAnalysisService>>());
+        });
         services.AddSingleton<IVideoMetadataService>(sp => sp.GetRequiredService<VideoAnalysisService>());
         services.AddSingleton<ShotTimelineSyncService>();
         services.AddSingleton<IFrameExtractionService, FrameExtractionService>();

--- a/Infrastructure/AI/Core/TwelveLabsOptions.cs
+++ b/Infrastructure/AI/Core/TwelveLabsOptions.cs
@@ -1,0 +1,48 @@
+namespace Storyboard.AI.Core;
+
+/// <summary>
+/// TwelveLabs (Pegasus) 视频理解配置。
+/// 该集成默认关闭：仅当 <see cref="ApiKey"/> 非空时才会用 Pegasus 丰富分镜描述，
+/// 否则保持原有的本地启发式分析行为不变（非破坏性）。
+///
+/// TwelveLabs (Pegasus) video-understanding options. This integration is opt-in:
+/// Pegasus is only used to enrich shot descriptions when <see cref="ApiKey"/> is set;
+/// otherwise the existing local heuristic analysis is used unchanged.
+/// </summary>
+public sealed class TwelveLabsOptions
+{
+    /// <summary>环境变量名：用于读取 API Key，避免把密钥写入仓库配置。</summary>
+    public const string ApiKeyEnvVar = "TWELVELABS_API_KEY";
+
+    /// <summary>TwelveLabs API Key。留空则禁用集成。优先从环境变量读取。</summary>
+    public string ApiKey { get; set; } = string.Empty;
+
+    /// <summary>REST 基地址。</summary>
+    public string Endpoint { get; set; } = "https://api.twelvelabs.io/v1.3";
+
+    /// <summary>Pegasus 模型名。</summary>
+    public string Model { get; set; } = "pegasus1.5";
+
+    /// <summary>单次请求超时（秒）。视频上传 + 分析可能较慢。</summary>
+    public int TimeoutSeconds { get; set; } = 300;
+
+    /// <summary>
+    /// 直传上传体积上限（字节）。TwelveLabs direct 上传上限为 200MB；
+    /// 超过则跳过 Pegasus 丰富、保留启发式结果。
+    /// </summary>
+    public long MaxUploadBytes { get; set; } = 200L * 1024 * 1024;
+
+    /// <summary>是否启用集成。</summary>
+    public bool IsEnabled => !string.IsNullOrWhiteSpace(ApiKey);
+
+    /// <summary>
+    /// 从环境变量构造配置；未设置 <see cref="ApiKeyEnvVar"/> 时返回禁用状态。
+    /// </summary>
+    public static TwelveLabsOptions FromEnvironment()
+    {
+        return new TwelveLabsOptions
+        {
+            ApiKey = Environment.GetEnvironmentVariable(ApiKeyEnvVar)?.Trim() ?? string.Empty
+        };
+    }
+}

--- a/Infrastructure/AI/Providers/TwelveLabsPegasusClient.cs
+++ b/Infrastructure/AI/Providers/TwelveLabsPegasusClient.cs
@@ -1,0 +1,177 @@
+using Microsoft.Extensions.Logging;
+using Storyboard.AI.Core;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Storyboard.AI.Providers;
+
+/// <summary>
+/// TwelveLabs Pegasus 视频理解的最小 REST 客户端。
+/// .NET 无官方 SDK，遵循其它 provider 的做法直接调用 v1.3 REST。
+///
+/// 流程：上传本地视频为 asset（POST /assets，method=direct）→ 用 asset_id 调用
+/// POST /analyze 拿到自然语言描述。Pegasus 1.5 不接受裸 video_id，必须用 url 或 asset_id。
+///
+/// Minimal REST client for TwelveLabs Pegasus. There is no official .NET SDK, so this
+/// follows the existing providers' pattern and calls the v1.3 REST API directly.
+/// </summary>
+public sealed class TwelveLabsPegasusClient
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly TwelveLabsOptions _options;
+    private readonly ILogger _logger;
+
+    public TwelveLabsPegasusClient(TwelveLabsOptions options, ILogger logger)
+    {
+        _options = options;
+        _logger = logger;
+    }
+
+    private HttpClient CreateClient()
+    {
+        var baseAddress = _options.Endpoint.EndsWith('/') ? _options.Endpoint : _options.Endpoint + "/";
+        var client = new HttpClient
+        {
+            BaseAddress = new Uri(baseAddress),
+            Timeout = TimeSpan.FromSeconds(_options.TimeoutSeconds)
+        };
+        client.DefaultRequestHeaders.Add("x-api-key", _options.ApiKey);
+        return client;
+    }
+
+    /// <summary>
+    /// 上传本地视频，返回处于 ready 状态的 asset_id；失败返回 null。
+    /// </summary>
+    public async Task<string?> UploadAssetAsync(string videoPath, CancellationToken cancellationToken)
+    {
+        if (!File.Exists(videoPath))
+        {
+            _logger.LogWarning("TwelveLabs: video file not found, skipping: {Path}", videoPath);
+            return null;
+        }
+
+        var length = new FileInfo(videoPath).Length;
+        if (length > _options.MaxUploadBytes)
+        {
+            _logger.LogWarning(
+                "TwelveLabs: video {Path} is {Size}MB, exceeds direct-upload limit ({Limit}MB); skipping Pegasus enrichment.",
+                videoPath, length / (1024 * 1024), _options.MaxUploadBytes / (1024 * 1024));
+            return null;
+        }
+
+        using var client = CreateClient();
+        await using var stream = File.OpenRead(videoPath);
+        using var form = new MultipartFormDataContent
+        {
+            { new StringContent("direct"), "method" }
+        };
+        var fileContent = new StreamContent(stream);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue("video/mp4");
+        form.Add(fileContent, "file", Path.GetFileName(videoPath));
+
+        using var response = await client.PostAsync("assets", form, cancellationToken).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("TwelveLabs asset upload failed ({Status}): {Body}", (int)response.StatusCode, body);
+            return null;
+        }
+
+        using var doc = JsonDocument.Parse(body);
+        var root = doc.RootElement;
+        var assetId = root.TryGetProperty("_id", out var id1) ? id1.GetString()
+            : root.TryGetProperty("asset_id", out var id2) ? id2.GetString()
+            : null;
+
+        if (string.IsNullOrWhiteSpace(assetId))
+        {
+            _logger.LogWarning("TwelveLabs asset upload returned no id: {Body}", body);
+            return null;
+        }
+
+        return await WaitForAssetReadyAsync(client, assetId!, cancellationToken).ConfigureAwait(false) ? assetId : null;
+    }
+
+    private async Task<bool> WaitForAssetReadyAsync(HttpClient client, string assetId, CancellationToken cancellationToken)
+    {
+        // 轮询直至 ready（或超时窗口耗尽）。
+        for (var attempt = 0; attempt < 60; attempt++)
+        {
+            cancellationToken.ThrowIfCancellationRequested();
+            using var response = await client.GetAsync($"assets/{assetId}", cancellationToken).ConfigureAwait(false);
+            var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            if (!response.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("TwelveLabs asset status check failed ({Status}): {Body}", (int)response.StatusCode, body);
+                return false;
+            }
+
+            using var doc = JsonDocument.Parse(body);
+            var status = doc.RootElement.TryGetProperty("status", out var s) ? s.GetString() : null;
+            if (string.Equals(status, "ready", StringComparison.OrdinalIgnoreCase))
+                return true;
+            if (string.Equals(status, "failed", StringComparison.OrdinalIgnoreCase))
+            {
+                _logger.LogWarning("TwelveLabs asset {AssetId} failed to process.", assetId);
+                return false;
+            }
+
+            await Task.Delay(TimeSpan.FromSeconds(5), cancellationToken).ConfigureAwait(false);
+        }
+
+        _logger.LogWarning("TwelveLabs asset {AssetId} did not become ready in time.", assetId);
+        return false;
+    }
+
+    /// <summary>
+    /// 对已上传的 asset 运行 Pegasus 分析，返回生成文本；失败返回 null。
+    /// startTime/endTime 为可选的剪辑窗口（Pegasus 要求窗口 ≥ 4 秒）。
+    /// </summary>
+    public async Task<string?> AnalyzeAssetAsync(
+        string assetId,
+        string prompt,
+        double? startTime,
+        double? endTime,
+        CancellationToken cancellationToken)
+    {
+        var payload = new Dictionary<string, object?>
+        {
+            ["model_name"] = _options.Model,
+            ["video"] = new Dictionary<string, object?> { ["type"] = "asset_id", ["asset_id"] = assetId },
+            ["prompt"] = prompt,
+            ["max_tokens"] = 512,
+            // 非流式：返回单个 {"id","data",...} 对象（data 即生成文本）。
+            // 默认流式会返回 NDJSON 事件流，这里不需要。
+            ["stream"] = false
+        };
+
+        // Pegasus 要求分析窗口 ≥ 4 秒，否则不附加窗口（分析整段）。
+        if (startTime is { } start && endTime is { } end && end - start >= 4.0)
+        {
+            payload["start_time"] = start;
+            payload["end_time"] = end;
+        }
+
+        using var client = CreateClient();
+        var json = JsonSerializer.Serialize(payload);
+        using var content = new StringContent(json, Encoding.UTF8, "application/json");
+        using var response = await client.PostAsync("analyze", content, cancellationToken).ConfigureAwait(false);
+        var body = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("TwelveLabs analyze failed ({Status}): {Body}", (int)response.StatusCode, body);
+            return null;
+        }
+
+        using var doc = JsonDocument.Parse(body);
+        var text = doc.RootElement.TryGetProperty("data", out var data) ? data.GetString() : null;
+        return string.IsNullOrWhiteSpace(text) ? null : text!.Trim();
+    }
+}

--- a/Infrastructure/Services/TwelveLabsVideoAnalysisService.cs
+++ b/Infrastructure/Services/TwelveLabsVideoAnalysisService.cs
@@ -1,0 +1,134 @@
+using Microsoft.Extensions.Logging;
+using Storyboard.AI.Core;
+using Storyboard.AI.Providers;
+using Storyboard.Application.Abstractions;
+using Storyboard.Models;
+
+namespace Storyboard.Infrastructure.Services;
+
+/// <summary>
+/// 用 TwelveLabs Pegasus 视频理解丰富分镜描述的装饰器。
+///
+/// 复用内层 <see cref="IVideoAnalysisService"/>（ffprobe/ffmpeg 场景切分得到真实镜头时长），
+/// 然后在配置了 API Key 时调用 Pegasus，把每个镜头的占位文案
+/// （如“画面内容（待分析）”）替换为真实的场景/景别描述。
+///
+/// 默认关闭：未设置 <c>TWELVELABS_API_KEY</c> 时直接透传内层结果，行为完全不变。
+///
+/// Opt-in decorator that enriches storyboard shot descriptions with TwelveLabs Pegasus.
+/// It reuses the inner heuristic analyzer for real shot timings, then (only when an API key
+/// is configured) uses Pegasus to replace placeholder shot text with real scene labels.
+/// With no key configured, it transparently passes through the original result.
+/// </summary>
+public sealed class TwelveLabsVideoAnalysisService : IVideoAnalysisService, IVideoMetadataService
+{
+    // 内层服务产生的占位文案；仅当字段仍是占位/空白时才覆盖，避免覆盖用户已编辑内容。
+    private const string PlaceholderCoreContent = "画面内容（待分析）";
+
+    private const string ShotPrompt =
+        "You are labeling one shot of a storyboard. In Chinese, reply with exactly three lines, no extra text:\n" +
+        "核心内容: <one concise sentence describing what happens in frame>\n" +
+        "景别: <one of 远景/全景/中景/近景/特写>\n" +
+        "场景: <setting and lighting in a few words>";
+
+    private readonly IVideoAnalysisService _inner;
+    private readonly TwelveLabsOptions _options;
+    private readonly ILogger<TwelveLabsVideoAnalysisService> _logger;
+
+    public TwelveLabsVideoAnalysisService(
+        IVideoAnalysisService inner,
+        TwelveLabsOptions options,
+        ILogger<TwelveLabsVideoAnalysisService> logger)
+    {
+        _inner = inner;
+        _options = options;
+        _logger = logger;
+    }
+
+    public Task<VideoMetadata> GetMetadataAsync(string videoPath, CancellationToken cancellationToken = default)
+    {
+        // 元数据探测与 Pegasus 无关，直接透传给内层（同时实现 IVideoMetadataService）。
+        return _inner is IVideoMetadataService meta
+            ? meta.GetMetadataAsync(videoPath, cancellationToken)
+            : throw new NotSupportedException("Inner analysis service does not provide metadata.");
+    }
+
+    public async Task<VideoAnalysisResult> AnalyzeVideoAsync(string videoPath)
+    {
+        var result = await _inner.AnalyzeVideoAsync(videoPath).ConfigureAwait(false);
+
+        if (!_options.IsEnabled || result.Shots.Count == 0)
+            return result; // 未启用 → 原样返回（非破坏性默认）。
+
+        try
+        {
+            await EnrichWithPegasusAsync(videoPath, result).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            // Pegasus 是可选增强，任何失败都不应破坏既有的启发式结果。
+            _logger.LogWarning(ex, "TwelveLabs Pegasus enrichment failed; returning heuristic result.");
+        }
+
+        return result;
+    }
+
+    private async Task EnrichWithPegasusAsync(string videoPath, VideoAnalysisResult result)
+    {
+        var client = new TwelveLabsPegasusClient(_options, _logger);
+
+        _logger.LogInformation("TwelveLabs: uploading {Path} for Pegasus analysis.", videoPath);
+        var assetId = await client.UploadAssetAsync(videoPath, CancellationToken.None).ConfigureAwait(false);
+        if (assetId == null)
+            return; // 上传失败/过大已在客户端记录日志，保留启发式结果。
+
+        foreach (var shot in result.Shots)
+        {
+            // 仅丰富仍为占位/空白的字段，避免覆盖用户已编辑内容。
+            if (!IsPlaceholder(shot))
+                continue;
+
+            var text = await client.AnalyzeAssetAsync(
+                assetId, ShotPrompt, shot.StartTime, shot.EndTime, CancellationToken.None).ConfigureAwait(false);
+            if (string.IsNullOrWhiteSpace(text))
+                continue;
+
+            ApplyPegasusText(shot, text);
+        }
+    }
+
+    private static bool IsPlaceholder(ShotItem shot) =>
+        string.IsNullOrWhiteSpace(shot.CoreContent) ||
+        shot.CoreContent == PlaceholderCoreContent;
+
+    /// <summary>把 Pegasus 的三行输出解析到对应字段；解析失败时整体写入核心内容。</summary>
+    private static void ApplyPegasusText(ShotItem shot, string text)
+    {
+        var matched = false;
+        foreach (var raw in text.Split('\n'))
+        {
+            var line = raw.Trim();
+            if (TryStrip(line, "核心内容", out var core)) { shot.CoreContent = core; matched = true; }
+            else if (TryStrip(line, "景别", out var shotType)) { shot.ShotType = shotType; matched = true; }
+            else if (TryStrip(line, "场景", out var scene)) { shot.SceneSettings = scene; matched = true; }
+        }
+
+        if (!matched)
+            shot.CoreContent = text.Trim();
+    }
+
+    private static bool TryStrip(string line, string label, out string value)
+    {
+        value = string.Empty;
+        var idx = line.IndexOf(label, StringComparison.Ordinal);
+        if (idx < 0)
+            return false;
+
+        var rest = line[(idx + label.Length)..].TrimStart('：', ':', ' ', '\t');
+        if (string.IsNullOrWhiteSpace(rest))
+            return false;
+
+        value = rest.Trim();
+        return true;
+    }
+}

--- a/README.en.md
+++ b/README.en.md
@@ -642,6 +642,27 @@ After first startup, configure AI providers to use AI features:
 
 </details>
 
+<details>
+<summary><b>Optional: TwelveLabs Pegasus video understanding</b></summary>
+
+When you import an existing video, Storyboard splits it into shots locally (ffprobe/ffmpeg scene cuts) and fills each shot with placeholder text (e.g. `画面内容（待分析）`). You can optionally have **[TwelveLabs](https://twelvelabs.io) Pegasus** watch each shot and replace those placeholders with real scene descriptions, shot types, and settings.
+
+This integration is **opt-in and non-breaking**: it is only active when an API key is present. With no key configured, video analysis behaves exactly as before.
+
+Enable it by setting an environment variable before launching the app:
+
+```bash
+export TWELVELABS_API_KEY="tlk_your_key_here"
+```
+
+Notes:
+- Each imported video is uploaded once to TwelveLabs, then each shot's time window is analyzed with Pegasus 1.5. Only placeholder/empty fields are filled — your manual edits are never overwritten.
+- Direct upload is capped at 200 MB; larger files are skipped and keep the local heuristic result.
+- Any TwelveLabs error falls back silently to the local analysis, so analysis never fails because of this provider.
+- You can grab a free API key at <https://twelvelabs.io> — there's a generous free tier.
+
+</details>
+
 #### 2. Create Your First Project
 
 1. Click **"Create New Project"**

--- a/README.md
+++ b/README.md
@@ -519,6 +519,27 @@ dotnet run
 
 </details>
 
+<details>
+<summary><b>可选：TwelveLabs Pegasus 视频理解</b></summary>
+
+导入已有视频时，Storyboard 会在本地（ffprobe/ffmpeg 场景切分）把视频拆分成镜头，并为每个镜头填入占位文案（如 `画面内容（待分析）`）。你可以选择让 **[TwelveLabs](https://twelvelabs.io) Pegasus** 观看每个镜头，把这些占位文案替换成真实的画面描述、景别和场景。
+
+该集成 **默认关闭、非破坏性**：仅在配置了 API Key 时才生效；未配置时，视频分析行为与之前完全一致。
+
+启动应用前设置环境变量即可启用：
+
+```bash
+export TWELVELABS_API_KEY="tlk_your_key_here"
+```
+
+说明：
+- 每个导入的视频只上传一次到 TwelveLabs，然后用 Pegasus 1.5 按镜头时间窗逐个分析。仅填充占位/空白字段，不会覆盖你手动编辑过的内容。
+- 直传上限为 200 MB，超过则跳过并保留本地启发式结果。
+- 任何 TwelveLabs 错误都会静默回退到本地分析，不会因为该提供商而导致分析失败。
+- 可在 <https://twelvelabs.io> 免费获取 API Key，提供慷慨的免费额度。
+
+</details>
+
 #### 2. 创建第一个项目
 
 1. 点击 **"创建新项目"**


### PR DESCRIPTION
Hi! I'm Mohit, I work at TwelveLabs (@mohit-twelvelabs).

## 简介（中文）

导入已有视频时，Storyboard 会在本地用 ffprobe/ffmpeg 把视频拆成镜头，并给每个镜头填入占位文案（如 `画面内容（待分析）`）。本 PR 增加一个**可选的** TwelveLabs Pegasus（视频理解）集成：配置了 `TWELVELABS_API_KEY` 时，用 Pegasus 观看每个镜头并把占位文案替换成真实的画面描述、景别和场景，从而更好地组织 / 标注分镜素材。

- **默认关闭、非破坏性**：未配置 Key 时，视频分析与现在完全一致。
- 实现为 `IVideoAnalysisService` 的装饰器，沿用现有 provider 模式（无官方 .NET SDK，直接调用 v1.3 REST，`x-api-key` 鉴权）。
- 每个视频只上传一次，再按镜头时间窗逐个分析（Pegasus 1.5）；仅填充占位/空白字段，不覆盖用户已编辑内容；任何错误都静默回退到本地结果。
- 可在 https://twelvelabs.io 免费获取 API Key，有慷慨的免费额度。

> ⚠️ 说明：我无法在本环境（Linux/macOS 沙箱）构建本项目——它是 `WinExe`，依赖 LibVLC 等原生库，环境里也没有 .NET SDK。所以我**没有**编译验证。代码严格对照现有 provider（Qwen/火山）和 `VideoAnalysisService` 的写法，请在你的平台上构建确认。我已**实测** TwelveLabs REST 契约（见下方 English 部分）。

## Summary (English)

When you import an existing video, Storyboard splits it into shots locally (ffprobe/ffmpeg scene cuts) and fills each shot with placeholder text (e.g. `画面内容（待分析）`). This PR adds an **opt-in** TwelveLabs Pegasus (video understanding) integration: when `TWELVELABS_API_KEY` is set, Pegasus watches each shot and replaces the placeholders with real scene descriptions, shot types, and settings — useful for labeling/organizing storyboard assets.

**What it adds**
- `Infrastructure/AI/Core/TwelveLabsOptions.cs` — opt-in config; reads the key from the `TWELVELABS_API_KEY` env var (no key is hardcoded).
- `Infrastructure/AI/Providers/TwelveLabsPegasusClient.cs` — minimal v1.3 REST client (upload asset → poll ready → analyze by `asset_id`), mirroring the existing providers' pattern. There is no official .NET SDK, so REST is the right approach here.
- `Infrastructure/Services/TwelveLabsVideoAnalysisService.cs` — an `IVideoAnalysisService` decorator that enriches placeholder shot fields.
- DI wiring in `App/App.axaml.cs` (decorator only activates when a key is present).
- README.md / README.en.md docs.

**Why it helps this project**
The repo already advertises multi-provider AI and a "Text Understanding" capability, but imported videos only get heuristic placeholder shot descriptions. Pegasus turns those into real, content-aware labels, which is exactly the kind of asset organization this tool is for.

**Opt-in / non-breaking**
The decorator is only inserted when `TWELVELABS_API_KEY` is set; otherwise the existing `VideoAnalysisService` is used unchanged. Only placeholder/empty fields are filled, so manual edits are never overwritten, and any TwelveLabs error falls back silently to the local result.

**How it was tested**
- I **live-verified the exact REST contract** this code uses against `api.twelvelabs.io/v1.3`: uploaded a video asset via `POST /assets` (`method=direct`) → got `{"_id","status":"ready"}`; analyzed by `asset_id` with a time window via `POST /analyze` using `"stream": false` and Pegasus 1.5 → got `{"id","data",...}` where `data` is the generated text (incl. the three-line `核心内容/景别/场景` format the parser expects). (During this I found and fixed that `/analyze` streams NDJSON by default, so the client sends `"stream": false`.)
- I unit-checked the response-parsing logic (`核心内容/景别/场景`, full-width-colon and fallback cases) offline.
- **Build limitation (honest):** I could not compile the project — it's a Windows/`WinExe` Avalonia app with native LibVLC dependencies, and no .NET SDK was available in my sandbox. The code follows the existing provider conventions precisely; please build on your platform to confirm. The repo has no test project, so I did not add one (adding a test SDK to this single-project app would be out of convention) — happy to add one if you'd like.

You can grab a free API key at https://twelvelabs.io — there's a generous free tier.
